### PR TITLE
allow option getNextValue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -166,8 +166,15 @@ exports.register = function(plugin, config, next) {
               uri += '?';
             }
 
+            var nextValue;
+            if (typeof options.getNextValue === 'function') {
+              nextValue = options.getNextValue.call(undefined, request);
+            } else {
+              nextValue = encodeURIComponent(request.url.path);
+            }
+
             uri += options.appendNext + '=' +
-             encodeURIComponent(request.url.path);
+             nextValue;
           }
 
           return reply('You are being redirected...', null, result)

--- a/test/index.js
+++ b/test/index.js
@@ -13,133 +13,515 @@ var lab = exports.lab = Lab.script(),
   expect = Code.expect;
 
 describe('scheme', function() {
-  /**
-   * Register a new user in Couch
-   * @param {Function} done The callback
-   */
-  lab.before(function(done) {
-    execSync(
-      'curl -X PUT http://localhost:5984/_users/org.couchdb.user:tester ' +
-      '-H "Accept: application/json" -H "Content-Type: application/json" ' +
-      '-d \'{"name": "tester", "password": "pw", "roles": [], "type": "user"}\''
-    );
-    done();
-  });
+/**
+ * Register a new user in Couch
+ * @param {Function} done The callback
+ */
+lab.before(function(done) {
+  execSync(
+    'curl -X PUT http://localhost:5984/_users/org.couchdb.user:tester ' +
+    '-H "Accept: application/json" -H "Content-Type: application/json" ' +
+    '-d \'{"name": "tester", "password": "pw", "roles": [], "type": "user"}\''
+  );
+  done();
+});
 
-  /**
-   * Remove the test user in Couch
-   * @param {Function} done The callback
-   */
-  lab.after(function(done) {
-    execSync(
-      'curl -X DEL http://localhost:5984/_users/org.couchdb.user:tester'
-    );
-    done();
-  });
+/**
+ * Remove the test user in Couch
+ * @param {Function} done The callback
+ */
+lab.after(function(done) {
+  execSync(
+    'curl -X DEL http://localhost:5984/_users/org.couchdb.user:tester'
+  );
+  done();
+});
 
-  it('authenticates a request', function(done) {
-    var server = new Hapi.Server();
+it('authenticates a request', function(done) {
+  var server = new Hapi.Server();
 
-    server.connection();
-    server.register(require('../'), function(error) {
-      expect(error).to.not.exist();
+  server.connection();
+  server.register(require('../'), function(error) {
+    expect(error).to.not.exist();
 
-      server.auth.strategy('default', 'couchdb-cookie', true, {
-        validateFunc: function(session, callback) {
-          var override = Hoek.clone(session);
-          override.something = 'new';
+    server.auth.strategy('default', 'couchdb-cookie', true, {
+      validateFunc: function(session, callback) {
+        var override = Hoek.clone(session);
+        override.something = 'new';
 
-          return callback(null, session.name === 'tester', override);
+        return callback(null, session.name === 'tester', override);
+      }
+    });
+
+    server.route({
+      method: 'POST',
+      path: '/login',
+      config: {
+        auth: {
+          mode: 'try'
+        },
+        handler: function(request, reply) {
+          request.auth.session.authenticate(
+            request.payload.username,
+            request.payload.password,
+            function(authError, credentials) {
+              expect(authError).to.not.exist();
+              expect(credentials).to.exist();
+              expect(credentials.name).to.equal('tester');
+              reply(request.payload.username + request.payload.password);
+            }
+          );
         }
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/resource',
+      handler: function(request, reply) {
+        expect(request.auth.credentials.something).to.equal('new');
+        return reply('resource');
+      }
+    });
+
+    server.inject({
+      method: 'POST',
+      url: '/login',
+      payload: '{"username":"tester","password":"pw"}'
+    }, function(validResponse) {
+      expect(validResponse.result).to.equal('testerpw');
+
+      var header = validResponse.headers['set-cookie'];
+      expect(header.length).to.equal(1);
+
+      var cookie = header[0].split(';');
+
+      server.inject({
+        method: 'GET',
+        url: '/resource',
+        headers: {
+          cookie: cookie[0]
+        }
+      }, function(resourceResponse) {
+        expect(resourceResponse.statusCode).to.equal(200);
+        expect(resourceResponse.headers['set-cookie']).to.not.exist();
+        expect(resourceResponse.result).to.equal('resource');
+        done();
       });
+    });
+  });
+});
+
+it('denies a request without auth', function(done) {
+  var server = new Hapi.Server();
+
+  server.connection();
+  server.register(require('../'), function(error) {
+    expect(error).to.not.exist();
+
+    server.auth.strategy('default', 'couchdb-cookie', true, {
+      validateFunc: function(session, callback) {
+        var override = Hoek.clone(session);
+        override.something = 'new';
+
+        return callback(null, session.name === 'tester', override);
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/resource',
+      handler: function(request, reply) {
+        expect(request.auth.credentials.something).to.equal('new');
+        return reply('resource');
+      }
+    });
+
+    server.inject({
+      method: 'GET',
+      url: '/resource'
+    }, function(resourceResponse) {
+      expect(resourceResponse.statusCode).to.equal(401);
+      expect(resourceResponse.headers['set-cookie'][0])
+        .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
+          '01 Jan 1970 00:00:00 GMT');
+      done();
+    });
+  });
+});
+
+it('fails over to another strategy if not present', function(done) {
+  var extraSchemePlugin = function(plugin, options, next) {
+    var simpleTestSchema = function() {
+      return {
+        authenticate: function(request, reply) {
+          return reply.continue({
+            credentials: {
+              test: 'valid'
+            }
+          });
+        }
+      };
+    };
+
+    plugin.auth.scheme('simpleTest', simpleTestSchema);
+    return next();
+  };
+
+  extraSchemePlugin.attributes = {
+    name: 'simpleTestAuth'
+  };
+
+  var server = new Hapi.Server();
+
+  server.connection();
+  server.register(require('../'), function(error) {
+    expect(error).to.not.exist();
+
+    server.auth.strategy('default', 'couchdb-cookie', true, {
+      validateFunc: function(session, callback) {
+        var override = Hoek.clone(session);
+        override.something = 'new';
+
+        return callback(null, session.name === 'tester', override);
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/login/{username}',
+      config: {
+        auth: {
+          mode: 'try'
+        },
+        handler: function(request, reply) {
+          return reply(request.params.username);
+        }
+      }
+    });
+
+    server.register(extraSchemePlugin, function(registerError) {
+      expect(registerError).to.not.exist();
+
+      server.auth.strategy('simple', 'simpleTest');
 
       server.route({
-        method: 'POST',
-        path: '/login',
+        method: 'GET',
+        path: '/multiple',
         config: {
           auth: {
-            mode: 'try'
+            mode: 'try',
+            strategies: ['default', 'simple']
           },
           handler: function(request, reply) {
-            request.auth.session.authenticate(
-              request.payload.username,
-              request.payload.password,
-              function(authError, credentials) {
-                expect(authError).to.not.exist();
-                expect(credentials).to.exist();
-                expect(credentials.name).to.equal('tester');
-                reply(request.payload.username + request.payload.password);
-              }
-            );
+            var credentialsTest = request.auth.credentials &&
+              request.auth.credentials.test || 'NOT AUTH';
+            return reply('multiple ' + credentialsTest);
           }
         }
       });
 
-      server.route({
-        method: 'GET',
-        path: '/resource',
-        handler: function(request, reply) {
-          expect(request.auth.credentials.something).to.equal('new');
-          return reply('resource');
-        }
+      server.inject('/multiple', function(res) {
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.equal('multiple valid');
+        done();
       });
+    });
+  });
+});
+
+it('ends a session', function(done) {
+  var server = new Hapi.Server();
+  server.connection();
+  server.register(require('../'), function(error) {
+    expect(error).to.not.exist();
+
+    server.auth.strategy('default', 'couchdb-cookie', true, {
+      validateFunc: function(session, callback) {
+        var override = Hoek.clone(session);
+        override.something = 'new';
+
+        return callback(null, session.name === 'tester', override);
+      }
+    });
+
+    server.route({
+      method: 'POST',
+      path: '/login',
+      config: {
+        auth: {
+          mode: 'try'
+        },
+        handler: function(request, reply) {
+          request.auth.session.authenticate(
+            request.payload.username,
+            request.payload.password,
+            function() {
+              reply(request.payload.username);
+            }
+          );
+        }
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/logout',
+      handler: function(request, reply) {
+        request.auth.session.clear();
+        return reply('logged-out');
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/resource',
+      handler: function(request, reply) {
+        expect(request.auth.credentials.something).to.equal('new');
+        return reply('resource');
+      }
+    });
+
+    server.inject({
+      method: 'POST',
+      url: '/login',
+      payload: '{"username":"tester","password":"pw"}'
+    },
+    function(res) {
+      expect(res.result).to.equal('tester');
+      var header = res.headers['set-cookie'];
+      expect(header.length).to.equal(1);
+      var cookie = header[0].split(';');
 
       server.inject({
-        method: 'POST',
-        url: '/login',
-        payload: '{"username":"tester","password":"pw"}'
-      }, function(validResponse) {
-        expect(validResponse.result).to.equal('testerpw');
+        method: 'GET',
+        url: '/logout',
+        headers: {
+          cookie: cookie[0]
+        }
+      }, function(logoutRes) {
+        expect(logoutRes.statusCode).to.equal(200);
+        expect(logoutRes.result).to.equal('logged-out');
 
-        var header = validResponse.headers['set-cookie'];
-        expect(header.length).to.equal(1);
-
-        var cookie = header[0].split(';');
+        var logoutHeader = logoutRes.headers['set-cookie'];
+        expect(logoutHeader.length).to.equal(1);
+        expect(logoutHeader[0])
+          .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
+            '01 Jan 1970 00:00:00 GMT');
+        var logoutCookie = logoutHeader[0].split(';');
 
         server.inject({
           method: 'GET',
           url: '/resource',
           headers: {
-            cookie: cookie[0]
+            cookie: logoutCookie[0]
           }
         }, function(resourceResponse) {
-          expect(resourceResponse.statusCode).to.equal(200);
-          expect(resourceResponse.headers['set-cookie']).to.not.exist();
-          expect(resourceResponse.result).to.equal('resource');
+          expect(resourceResponse.statusCode).to.equal(401);
+          expect(resourceResponse.headers['set-cookie'][0])
+            .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
+              '01 Jan 1970 00:00:00 GMT');
+          expect(resourceResponse.result).to.not.equal('resource');
           done();
         });
       });
     });
   });
+});
 
-  it('denies a request without auth', function(done) {
-    var server = new Hapi.Server();
+it('fails a request with invalid session', function(done) {
+  var server = new Hapi.Server();
+  server.connection();
+  server.register(require('../'), function(error) {
+    expect(error).to.not.exist();
 
-    server.connection();
-    server.register(require('../'), function(error) {
-      expect(error).to.not.exist();
+    server.auth.strategy('default', 'couchdb-cookie', true, {
+      validateFunc: function(session, callback) {
+        var override = Hoek.clone(session);
 
-      server.auth.strategy('default', 'couchdb-cookie', true, {
-        validateFunc: function(session, callback) {
-          var override = Hoek.clone(session);
-          override.something = 'new';
+        override.something = 'new';
 
-          return callback(null, session.name === 'tester', override);
-        }
-      });
+        return callback(null, session.user === 'tester', override);
+      }
+    });
 
-      server.route({
-        method: 'GET',
-        path: '/resource',
+    server.route({
+      method: 'POST',
+      path: '/login',
+      config: {
+        auth: {
+          mode: 'try'
+        },
         handler: function(request, reply) {
-          expect(request.auth.credentials.something).to.equal('new');
-          return reply('resource');
+          request.auth.session.authenticate(
+            request.payload.username,
+            request.payload.password,
+            function(authError, credentials) {
+              expect(credentials).to.not.exist();
+              expect(authError).to.exist();
+              reply(request.payload.username);
+            }
+          );
         }
-      });
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/resource',
+      handler: function(request, reply) {
+        expect(request.auth.credentials.something).to.equal('new');
+        return reply('resource');
+      }
+    });
+
+    server.inject({
+      method: 'POST',
+      url: '/login',
+      payload: '{"username":"invalid","password":"pw"}'
+    },
+    function(res) {
+      expect(res.result).to.equal('invalid');
+      expect(res.headers['set-cookie'][0])
+        .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
+          '01 Jan 1970 00:00:00 GMT');
 
       server.inject({
         method: 'GET',
-        url: '/resource'
+        url: '/resource',
+        headers: {
+          cookie: ''
+        }
+      }, function(resourceRes) {
+        expect(resourceRes.headers['set-cookie'][0])
+          .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
+            '01 Jan 1970 00:00:00 GMT');
+        expect(resourceRes.statusCode).to.equal(401);
+        done();
+      });
+    });
+  });
+});
+
+it('logs in and authenticates a request', function(done) {
+  var server = new Hapi.Server();
+  server.connection();
+  server.register(require('../'), function(error) {
+    expect(error).to.not.exist();
+
+    server.auth.strategy('default', 'couchdb-cookie', true);
+
+    server.route({
+      method: 'POST',
+      path: '/login',
+      config: {
+        auth: {
+          mode: 'try'
+        },
+        handler: function(request, reply) {
+          request.auth.session.authenticate(
+            request.payload.username,
+            request.payload.password,
+            function() {
+              reply(request.payload.username + request.payload.password);
+            }
+          );
+        }
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/resource',
+      handler: function(request, reply) {
+        expect(request.auth.credentials.name).to.equal('tester');
+        return reply('resource');
+      }
+    });
+
+    server.inject({
+      method: 'POST',
+      url: '/login',
+      payload: '{"username":"tester","password":"pw"}'
+    },
+    function(validResponse) {
+      expect(validResponse.result).to.equal('testerpw');
+      var header = validResponse.headers['set-cookie'];
+      expect(header.length).to.equal(1);
+      var cookie = header[0].split(';');
+
+      server.inject({
+        method: 'GET',
+        url: '/resource',
+        headers: {
+          cookie: cookie[0]
+        }
+      }, function(resourceResponse) {
+        expect(resourceResponse.statusCode).to.equal(200);
+        expect(resourceResponse.result).to.equal('resource');
+        done();
+      });
+    });
+  });
+});
+
+it('errors in validation function', function(done) {
+  var server = new Hapi.Server();
+  server.connection();
+  server.register(require('../'), function(error) {
+    expect(error).to.not.exist();
+
+    server.auth.strategy('default', 'couchdb-cookie', true, {
+      validateFunc: function(session, callback) {
+        return callback(new Error('boom'));
+      }
+    });
+
+    server.route({
+      method: 'POST',
+      path: '/login',
+      config: {
+        auth: {
+          mode: 'try'
+        },
+        handler: function(request, reply) {
+          request.auth.session.authenticate(
+            request.payload.username,
+            request.payload.password,
+            function() {
+              reply(request.payload.username);
+            }
+          );
+        }
+      }
+    });
+
+    server.route({
+      method: 'GET',
+      path: '/resource',
+      handler: function(request, reply) {
+        expect(request.auth.credentials.name).to.equal('tester');
+        return reply('resource');
+      }
+    });
+
+    server.inject({
+      method: 'POST',
+      url: '/login',
+      payload: '{"username":"tester","password":"pw"}'
+    },
+    function(validResponse) {
+      expect(validResponse.result).to.equal('tester');
+      var header = validResponse.headers['set-cookie'];
+      expect(header.length).to.equal(1);
+      var cookie = header[0].split(';');
+
+      server.inject({
+        method: 'GET',
+        url: '/resource',
+        headers: {
+          cookie: cookie[0]
+        }
       }, function(resourceResponse) {
         expect(resourceResponse.statusCode).to.equal(401);
         expect(resourceResponse.headers['set-cookie'][0])
@@ -149,450 +531,68 @@ describe('scheme', function() {
       });
     });
   });
+});
 
-  it('fails over to another strategy if not present', function(done) {
-    var extraSchemePlugin = function(plugin, options, next) {
-      var simpleTestSchema = function() {
-        return {
-          authenticate: function(request, reply) {
-            return reply.continue({
-              credentials: {
-                test: 'valid'
-              }
-            });
-          }
-        };
-      };
+it('clear cookie on invalid', function(done) {
+  var server = new Hapi.Server();
+  server.connection();
+  server.register(require('../'), function(error) {
+    expect(error).to.not.exist();
 
-      plugin.auth.scheme('simpleTest', simpleTestSchema);
-      return next();
-    };
+    server.auth.strategy('default', 'couchdb-cookie', true);
 
-    extraSchemePlugin.attributes = {
-      name: 'simpleTestAuth'
-    };
+    server.route({
+      method: 'GET',
+      path: '/',
+      handler: function(request, reply) {
+        return reply();
+      }
+    });
 
-    var server = new Hapi.Server();
-
-    server.connection();
-    server.register(require('../'), function(error) {
-      expect(error).to.not.exist();
-
-      server.auth.strategy('default', 'couchdb-cookie', true, {
-        validateFunc: function(session, callback) {
-          var override = Hoek.clone(session);
-          override.something = 'new';
-
-          return callback(null, session.name === 'tester', override);
-        }
-      });
-
-      server.route({
-        method: 'GET',
-        path: '/login/{username}',
-        config: {
-          auth: {
-            mode: 'try'
-          },
-          handler: function(request, reply) {
-            return reply(request.params.username);
-          }
-        }
-      });
-
-      server.register(extraSchemePlugin, function(registerError) {
-        expect(registerError).to.not.exist();
-
-        server.auth.strategy('simple', 'simpleTest');
-
-        server.route({
-          method: 'GET',
-          path: '/multiple',
-          config: {
-            auth: {
-              mode: 'try',
-              strategies: ['default', 'simple']
-            },
-            handler: function(request, reply) {
-              var credentialsTest = request.auth.credentials &&
-                request.auth.credentials.test || 'NOT AUTH';
-              return reply('multiple ' + credentialsTest);
-            }
-          }
-        });
-
-        server.inject('/multiple', function(res) {
-          expect(res.statusCode).to.equal(200);
-          expect(res.result).to.equal('multiple valid');
-          done();
-        });
-      });
+    server.inject({
+      url: '/',
+      headers: {
+        cookie: 'AuthSession=123456'
+      }
+    }, function(res) {
+      expect(res.statusCode).to.equal(401);
+      expect(res.headers['set-cookie'][0])
+        .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
+          '01 Jan 1970 00:00:00 GMT');
+      done();
     });
   });
+});
 
-  it('ends a session', function(done) {
-    var server = new Hapi.Server();
-    server.connection();
-    server.register(require('../'), function(error) {
-      expect(error).to.not.exist();
+it('accepts a custom CouchDB url', function(done) {
+  var server = new Hapi.Server();
+  server.connection();
+  server.register(require('../'), function(error) {
+    expect(error).to.not.exist();
 
-      server.auth.strategy('default', 'couchdb-cookie', true, {
-        validateFunc: function(session, callback) {
-          var override = Hoek.clone(session);
-          override.something = 'new';
+    server.auth.strategy('default', 'couchdb-cookie', true, {
+      couchdbUrl: 'http://localhost:6984'
+    });
 
-          return callback(null, session.name === 'tester', override);
-        }
-      });
+    server.route({
+      method: 'GET',
+      path: '/',
+      handler: function(request, reply) {
+        return reply();
+      }
+    });
 
-      server.route({
-        method: 'POST',
-        path: '/login',
-        config: {
-          auth: {
-            mode: 'try'
-          },
-          handler: function(request, reply) {
-            request.auth.session.authenticate(
-              request.payload.username,
-              request.payload.password,
-              function() {
-                reply(request.payload.username);
-              }
-            );
-          }
-        }
-      });
-
-      server.route({
-        method: 'GET',
-        path: '/logout',
-        handler: function(request, reply) {
-          request.auth.session.clear();
-          return reply('logged-out');
-        }
-      });
-
-      server.route({
-        method: 'GET',
-        path: '/resource',
-        handler: function(request, reply) {
-          expect(request.auth.credentials.something).to.equal('new');
-          return reply('resource');
-        }
-      });
-
-      server.inject({
-        method: 'POST',
-        url: '/login',
-        payload: '{"username":"tester","password":"pw"}'
-      },
-      function(res) {
-        expect(res.result).to.equal('tester');
-        var header = res.headers['set-cookie'];
-        expect(header.length).to.equal(1);
-        var cookie = header[0].split(';');
-
-        server.inject({
-          method: 'GET',
-          url: '/logout',
-          headers: {
-            cookie: cookie[0]
-          }
-        }, function(logoutRes) {
-          expect(logoutRes.statusCode).to.equal(200);
-          expect(logoutRes.result).to.equal('logged-out');
-
-          var logoutHeader = logoutRes.headers['set-cookie'];
-          expect(logoutHeader.length).to.equal(1);
-          expect(logoutHeader[0])
-            .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
-              '01 Jan 1970 00:00:00 GMT');
-          var logoutCookie = logoutHeader[0].split(';');
-
-          server.inject({
-            method: 'GET',
-            url: '/resource',
-            headers: {
-              cookie: logoutCookie[0]
-            }
-          }, function(resourceResponse) {
-            expect(resourceResponse.statusCode).to.equal(401);
-            expect(resourceResponse.headers['set-cookie'][0])
-              .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
-                '01 Jan 1970 00:00:00 GMT');
-            expect(resourceResponse.result).to.not.equal('resource');
-            done();
-          });
-        });
-      });
+    server.inject({
+      url: '/',
+      headers: {
+        cookie: 'AuthSession=123456'
+      }
+    }, function(res) {
+      expect(res.statusCode).to.equal(500);
+      done();
     });
   });
-
-  it('fails a request with invalid session', function(done) {
-    var server = new Hapi.Server();
-    server.connection();
-    server.register(require('../'), function(error) {
-      expect(error).to.not.exist();
-
-      server.auth.strategy('default', 'couchdb-cookie', true, {
-        validateFunc: function(session, callback) {
-          var override = Hoek.clone(session);
-
-          override.something = 'new';
-
-          return callback(null, session.user === 'tester', override);
-        }
-      });
-
-      server.route({
-        method: 'POST',
-        path: '/login',
-        config: {
-          auth: {
-            mode: 'try'
-          },
-          handler: function(request, reply) {
-            request.auth.session.authenticate(
-              request.payload.username,
-              request.payload.password,
-              function(authError, credentials) {
-                expect(credentials).to.not.exist();
-                expect(authError).to.exist();
-                reply(request.payload.username);
-              }
-            );
-          }
-        }
-      });
-
-      server.route({
-        method: 'GET',
-        path: '/resource',
-        handler: function(request, reply) {
-          expect(request.auth.credentials.something).to.equal('new');
-          return reply('resource');
-        }
-      });
-
-      server.inject({
-        method: 'POST',
-        url: '/login',
-        payload: '{"username":"invalid","password":"pw"}'
-      },
-      function(res) {
-        expect(res.result).to.equal('invalid');
-        expect(res.headers['set-cookie'][0])
-          .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
-            '01 Jan 1970 00:00:00 GMT');
-
-        server.inject({
-          method: 'GET',
-          url: '/resource',
-          headers: {
-            cookie: ''
-          }
-        }, function(resourceRes) {
-          expect(resourceRes.headers['set-cookie'][0])
-            .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
-              '01 Jan 1970 00:00:00 GMT');
-          expect(resourceRes.statusCode).to.equal(401);
-          done();
-        });
-      });
-    });
-  });
-
-  it('logs in and authenticates a request', function(done) {
-    var server = new Hapi.Server();
-    server.connection();
-    server.register(require('../'), function(error) {
-      expect(error).to.not.exist();
-
-      server.auth.strategy('default', 'couchdb-cookie', true);
-
-      server.route({
-        method: 'POST',
-        path: '/login',
-        config: {
-          auth: {
-            mode: 'try'
-          },
-          handler: function(request, reply) {
-            request.auth.session.authenticate(
-              request.payload.username,
-              request.payload.password,
-              function() {
-                reply(request.payload.username + request.payload.password);
-              }
-            );
-          }
-        }
-      });
-
-      server.route({
-        method: 'GET',
-        path: '/resource',
-        handler: function(request, reply) {
-          expect(request.auth.credentials.name).to.equal('tester');
-          return reply('resource');
-        }
-      });
-
-      server.inject({
-        method: 'POST',
-        url: '/login',
-        payload: '{"username":"tester","password":"pw"}'
-      },
-      function(validResponse) {
-        expect(validResponse.result).to.equal('testerpw');
-        var header = validResponse.headers['set-cookie'];
-        expect(header.length).to.equal(1);
-        var cookie = header[0].split(';');
-
-        server.inject({
-          method: 'GET',
-          url: '/resource',
-          headers: {
-            cookie: cookie[0]
-          }
-        }, function(resourceResponse) {
-          expect(resourceResponse.statusCode).to.equal(200);
-          expect(resourceResponse.result).to.equal('resource');
-          done();
-        });
-      });
-    });
-  });
-
-  it('errors in validation function', function(done) {
-    var server = new Hapi.Server();
-    server.connection();
-    server.register(require('../'), function(error) {
-      expect(error).to.not.exist();
-
-      server.auth.strategy('default', 'couchdb-cookie', true, {
-        validateFunc: function(session, callback) {
-          return callback(new Error('boom'));
-        }
-      });
-
-      server.route({
-        method: 'POST',
-        path: '/login',
-        config: {
-          auth: {
-            mode: 'try'
-          },
-          handler: function(request, reply) {
-            request.auth.session.authenticate(
-              request.payload.username,
-              request.payload.password,
-              function() {
-                reply(request.payload.username);
-              }
-            );
-          }
-        }
-      });
-
-      server.route({
-        method: 'GET',
-        path: '/resource',
-        handler: function(request, reply) {
-          expect(request.auth.credentials.name).to.equal('tester');
-          return reply('resource');
-        }
-      });
-
-      server.inject({
-        method: 'POST',
-        url: '/login',
-        payload: '{"username":"tester","password":"pw"}'
-      },
-      function(validResponse) {
-        expect(validResponse.result).to.equal('tester');
-        var header = validResponse.headers['set-cookie'];
-        expect(header.length).to.equal(1);
-        var cookie = header[0].split(';');
-
-        server.inject({
-          method: 'GET',
-          url: '/resource',
-          headers: {
-            cookie: cookie[0]
-          }
-        }, function(resourceResponse) {
-          expect(resourceResponse.statusCode).to.equal(401);
-          expect(resourceResponse.headers['set-cookie'][0])
-            .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
-              '01 Jan 1970 00:00:00 GMT');
-          done();
-        });
-      });
-    });
-  });
-
-  it('clear cookie on invalid', function(done) {
-    var server = new Hapi.Server();
-    server.connection();
-    server.register(require('../'), function(error) {
-      expect(error).to.not.exist();
-
-      server.auth.strategy('default', 'couchdb-cookie', true);
-
-      server.route({
-        method: 'GET',
-        path: '/',
-        handler: function(request, reply) {
-          return reply();
-        }
-      });
-
-      server.inject({
-        url: '/',
-        headers: {
-          cookie: 'AuthSession=123456'
-        }
-      }, function(res) {
-        expect(res.statusCode).to.equal(401);
-        expect(res.headers['set-cookie'][0])
-          .to.equal('AuthSession=; Max-Age=0; Expires=Thu, ' +
-            '01 Jan 1970 00:00:00 GMT');
-        done();
-      });
-    });
-  });
-
-  it('accepts a custom CouchDB url', function(done) {
-    var server = new Hapi.Server();
-    server.connection();
-    server.register(require('../'), function(error) {
-      expect(error).to.not.exist();
-
-      server.auth.strategy('default', 'couchdb-cookie', true, {
-        couchdbUrl: 'http://localhost:6984'
-      });
-
-      server.route({
-        method: 'GET',
-        path: '/',
-        handler: function(request, reply) {
-          return reply();
-        }
-      });
-
-      server.inject({
-        url: '/',
-        headers: {
-          cookie: 'AuthSession=123456'
-        }
-      }, function(res) {
-        expect(res.statusCode).to.equal(500);
-        done();
-      });
-    });
-  });
+});
 
   describe('redirection', function() {
     it('sends to login page (uri without query)', function(done) {
@@ -712,8 +712,38 @@ describe('scheme', function() {
       });
     });
 
-    it(
-      'sends to login and does not append the next query on !appendNext',
+    it('sends to login page with custom next value', function(done) {
+      var server = new Hapi.Server();
+      server.connection();
+      server.register(require('../'), function(error) {
+        expect(error).to.not.exist();
+
+        server.auth.strategy('default', 'couchdb-cookie', true, {
+          redirectTo: 'http://example.com/login?mode=1',
+          getNextValue: function() {
+            return 'custom-next-value';
+          },
+          appendNext: true
+        });
+
+        server.route({
+          method: 'GET',
+          path: '/',
+          handler: function(request, reply) {
+            return reply('never');
+          }
+        });
+
+        server.inject('/', function(res) {
+          expect(res.statusCode).to.equal(302);
+          expect(res.headers.location)
+            .to.equal('http://example.com/login?mode=1&next=custom-next-value');
+          done();
+        });
+      });
+    });
+
+    it('sends to login and does not append the next query on !appendNext',
       function(done) {
         var server = new Hapi.Server();
         server.connection();


### PR DESCRIPTION
if `getNextValue` is a function, it gets called with the `request` as a parameter and should return a string that is appended to the url in the `next` parameter.

example:
```
server.auth.strategy('couchdb', 'couchdb-cookie', {
  couchdbUrl: process.env.COUCH_DB_URL,
  redirectTo: process.env.LOGIN_URL || '/login',
  appendNext: true,
  getNextValue: function(request) {
    return encodeURIComponent(request.url.path);
  }
});
```

If there are any questions or there is anything I can do to improve this, please let know.