### PR TITLE
allow option getNextValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Type `String|Boolean` | Default `false`
 If `true` and `redirectTo` is `true`, appends the current request path to the query component of the `redirectTo` URI using the parameter name `'next'`. Set to a string to use a different parameter name.
 Defaults to `false`.
 
+#### getNextValue
+Type `function` | Default `undefined`
+
+If `redirectTo` and `appendNext` are `true` and it is a `function`, `getNextValue` gets called with the `request` object as the only parameter. It should return a `String` that is used as the value of either `'next'` or the String set as `appendNext` in the url for the redirect.
+
 #### redirectOnTry
 Type `Boolean` | Default `true`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,8 +166,15 @@ exports.register = function(plugin, config, next) {
               uri += '?';
             }
 
-            uri += options.appendNext + '=' +
-             encodeURIComponent(request.url.path);
+            var nextValue;
+            if (typeof options.getNextValue === 'function') {
+              nextValue = options.getNextValue.call(undefined, request);
+            } else {
+              nextValue = encodeURIComponent(request.url.path);
+            }
+
+            uri += options.appendNext + '=' + nextValue;
+
           }
 
           return reply('You are being redirected...', null, result)

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,7 +168,7 @@ exports.register = function(plugin, config, next) {
 
             var nextValue;
             if (typeof options.getNextValue === 'function') {
-              nextValue = options.getNextValue.call(undefined, request);
+              nextValue = options.getNextValue.call(null, request);
             } else {
               nextValue = encodeURIComponent(request.url.path);
             }


### PR DESCRIPTION
if getNextValue is a function, it gets called with the request as a parameter and should return a string that is appended to the url in the next parameter.

example:
```
server.auth.strategy('couchdb', 'couchdb-cookie', {
  couchdbUrl: process.env.COUCH_DB_URL,
  redirectTo: process.env.LOGIN_URL || '/login',
  appendNext: true,
  getNextValue: function(request) {
    return encodeURIComponent(request.url.path);
  }
});
```
If there are any questions or there is anything I can do to improve this, please let know.